### PR TITLE
Modified varnish queries to get bulk api calls separately

### DIFF
--- a/push-athena-data-to-rds/athena/queries.go
+++ b/push-athena-data-to-rds/athena/queries.go
@@ -154,8 +154,7 @@ func VarnishDataQuery(queryParams map[string]string, db string, table string) (s
 	bulkRequestsWhereClause := sq.And{sq.Like{"request_url": bulkString},
 		sq.Eq{"year": yearString},
 		sq.Eq{"month": monthString},
-		sq.Eq{"day": dayString},
-		sq.NotEq{"request_url": nil}}
+		sq.Eq{"day": dayString}}
 
 	allRequestsWhereClause := sq.And{sq.Eq{"year": yearString},
 		sq.Eq{"month": monthString},


### PR DESCRIPTION
Along with all uncached requests, get all the bulk sketches requests from varnish logs.