### PR TITLE
Revert "Remove /api/v1 requests from frontend to avoid double counting(#21)"

### DIFF
--- a/push-athena-data-to-rds/athena/queries.go
+++ b/push-athena-data-to-rds/athena/queries.go
@@ -277,7 +277,6 @@ func FrontendHaproxyDataQuery(queryParams map[string]string, db string, table st
 	whereClause := sq.And{sq.Eq{"elb_status_code": fmt.Sprint("'", "200", "'")},
 		sq.NotLike{"request_url": fmt.Sprint("'", "%/?uptime%", "'")},
 		sq.NotLike{"request_url": fmt.Sprint("'", "%robots.txt%", "'")},
-		sq.NotLike{"request_url": fmt.Sprint("'", "%/api/v1%", "'")},
 		sq.NotLike{"request_url": fmt.Sprint("'", "%ping%", "'")},
 		sq.Eq{"year": yearString},
 		sq.Eq{"month": monthString},


### PR DESCRIPTION
This reverts commit da492dd7a876a7eafa398c413e628b0b95b6947f.

This is done for counting API calls in haproxy as well as varnish for custom publishers. 
This is based on the idea that custom publishers can optimize the number of varnish calls from code. They can selectively calls APIs or memorize API calls. 
Ahead-PB clients wont be charged for Varnish requests as they have no control over code.